### PR TITLE
Fix step size for word translations

### DIFF
--- a/document_translator/word/__init__.py
+++ b/document_translator/word/__init__.py
@@ -69,7 +69,7 @@ def main(
         text = para.text
         if text.strip():
             texts.append(text)
-    step = len(texts) // 100
+    step = max(1, len(texts) // 100)
     print(f"Total texts: {len(texts)}")
     texts = [
         text


### PR DESCRIPTION
## Summary
- avoid zero step size when processing docx paragraphs

## Testing
- `make tests`

------
https://chatgpt.com/codex/tasks/task_e_6844825416a883208a4f71815974052e