### PR TITLE
Fix PyPI link in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,5 +128,5 @@ jobs:
         if: steps.tag-check.outputs.exists == 'false'
         run: |
           echo "🚀 Release v${{ steps.package-version.outputs.version }} completed successfully!"
-          echo "📦 Published to PyPI: https://pypi.org/project/mcp-sys-bridge/"
+          echo "📦 Published to PyPI: https://pypi.org/project/document-translator/"
           echo "🏷️ GitHub release: https://github.com/${{ github.repository }}/releases/tag/v${{ steps.package-version.outputs.version }}"


### PR DESCRIPTION
## Summary
- correct the PyPI URL in the release workflow

## Testing
- `make tests`

------
https://chatgpt.com/codex/tasks/task_e_6844826535648320a02d9b8d7f9abaf9