### PR TITLE
Add env example and document API key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=tu_clave_aqui

--- a/README.md
+++ b/README.md
@@ -35,6 +35,17 @@ document-translator word [OPTIONS] COMMAND [ARGS]...
 * `--translator [openai]`: Translator  [default: openai]
 * `--help`: Show this message and exit.
 
+## Configuration
+
+The tool reads the OpenAI API key from the environment variable
+`OPENAI_API_KEY`. You can create a `.env` file at the project root by
+copying the provided example:
+
+```bash
+cp .env.example .env
+# then edit .env and replace the placeholder with your API key
+```
+
 ## Development
 
 Install dependencies with [uv](https://github.com/astral-sh/uv) and run the tool:


### PR DESCRIPTION
## Summary
- add `.env.example` with placeholder `OPENAI_API_KEY`
- document how to use `.env` in the README

## Testing
- `make tests`

------
https://chatgpt.com/codex/tasks/task_e_6844826a807c8320916ff44fa896b7c9