### PR TITLE
feat: add env example and document API key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=tu_clave_aqui

--- a/readme.md
+++ b/readme.md
@@ -44,3 +44,7 @@ uv lock
 uv sync --all-groups --all-extras
 uv run document-translator --help
 ```
+
+## Environment variables
+
+Copy `.env.example` to `.env` and set `OPENAI_API_KEY` with your OpenAI API key.


### PR DESCRIPTION
## Summary
- add `.env.example` with placeholder OpenAI API key
- describe how to configure `OPENAI_API_KEY` in README

## Testing
- `make tests`

------
https://chatgpt.com/codex/tasks/task_e_68449cbf7db08320b478ce1dace1138e