### PR TITLE
test: adjust environment setup for imports

### DIFF
--- a/makefile
+++ b/makefile
@@ -4,3 +4,4 @@ install:
 tests: install
 	uv run ruff check .
 	uv run ruff format --check .
+	uv run pytest -q

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,10 @@ dependencies = [
 ]
 
 [dependency-groups]
-dev = ["ruff>=0.4.7"]
+dev = [
+    "ruff>=0.4.7",
+    "pytest>=8.2.1",
+]
 
 [project.scripts]
 document-translator = "document_translator.main:app"

--- a/tests/test_styler.py
+++ b/tests/test_styler.py
@@ -1,0 +1,66 @@
+# ruff: noqa: E402
+import os
+from docx import Document
+from docx.enum.text import WD_ALIGN_PARAGRAPH
+from docx.shared import Inches, Pt, RGBColor
+
+os.environ.setdefault("OPENAI_API_KEY", "test")
+
+from document_translator.word.styler import copy_paragraph_style, copy_run_style
+
+
+def test_copy_run_style() -> None:
+    doc = Document()
+    run = doc.add_paragraph().add_run("hello")
+    run.bold = True
+    run.italic = True
+    run.underline = True
+    run.font.size = Pt(16)
+    run.font.name = "Arial"
+    run.font.color.rgb = RGBColor(0x11, 0x22, 0x33)
+
+    new_doc = Document()
+    new_run = new_doc.add_paragraph().add_run("world")
+    copy_run_style(run, new_run)
+
+    assert new_run.bold is True
+    assert new_run.italic is True
+    assert new_run.underline is True
+    assert new_run.font.size == Pt(16)
+    assert new_run.font.name == "Arial"
+    assert new_run.font.color.rgb == RGBColor(0x11, 0x22, 0x33)
+
+
+def test_copy_paragraph_style() -> None:
+    doc = Document()
+    para = doc.add_paragraph("text")
+    para.paragraph_format.left_indent = Inches(0.5)
+    para.paragraph_format.right_indent = Inches(0.25)
+    para.paragraph_format.space_before = Pt(12)
+    para.paragraph_format.space_after = Pt(6)
+    para.paragraph_format.line_spacing = 2
+    para.paragraph_format.keep_together = True
+    para.paragraph_format.keep_with_next = True
+    para.paragraph_format.page_break_before = True
+    para.paragraph_format.widow_control = True
+    para.style = doc.styles["Title"]
+    para.alignment = WD_ALIGN_PARAGRAPH.CENTER
+
+    new_doc = Document()
+    new_para = new_doc.add_paragraph()
+    copy_paragraph_style(para, new_para)
+
+    fmt1 = para.paragraph_format
+    fmt2 = new_para.paragraph_format
+
+    assert fmt2.left_indent == fmt1.left_indent
+    assert fmt2.right_indent == fmt1.right_indent
+    assert fmt2.space_before == fmt1.space_before
+    assert fmt2.space_after == fmt1.space_after
+    assert fmt2.line_spacing == fmt1.line_spacing
+    assert fmt2.keep_together == fmt1.keep_together
+    assert fmt2.keep_with_next == fmt1.keep_with_next
+    assert fmt2.page_break_before == fmt1.page_break_before
+    assert fmt2.widow_control == fmt1.widow_control
+    assert new_para.style.name == para.style.name
+    assert new_para.alignment == para.alignment

--- a/tests/test_word.py
+++ b/tests/test_word.py
@@ -1,0 +1,41 @@
+# ruff: noqa: E402
+import os
+from pathlib import Path
+from docx import Document
+from pytest import MonkeyPatch
+
+os.environ.setdefault("OPENAI_API_KEY", "test")
+
+from document_translator import word
+
+
+def test_segmentation(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    doc = Document()
+    texts = []
+    for i in range(250):
+        text = f"text {i}"
+        texts.append(text)
+        doc.add_paragraph(text)
+    input_file = tmp_path / "input.docx"
+    doc.save(str(input_file))
+    output_file = tmp_path / "output.docx"
+
+    segments: list[list[str]] = []
+
+    def fake_translate(items: list[str], ls: str, lt: str) -> list[str]:
+        segments.append(list(items))
+        return list(items)
+
+    monkeypatch.setattr(word, "get_translator", lambda _: fake_translate)
+
+    word.main(
+        input=input_file,
+        output=str(output_file),
+        language_source="es",
+        language_target="en",
+    )
+
+    step = len(texts) // 100
+    expected = [texts[i : i + step] for i in range(0, len(texts), step)]
+    assert segments == expected
+    assert output_file.exists()

--- a/uv.lock
+++ b/uv.lock
@@ -78,6 +78,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pytest" },
     { name = "ruff" },
 ]
 
@@ -91,7 +92,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "ruff", specifier = ">=0.4.7" }]
+dev = [
+    { name = "pytest", specifier = ">=8.2.1" },
+    { name = "ruff", specifier = ">=0.4.7" },
+]
 
 [[package]]
 name = "h11"
@@ -137,6 +141,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
 ]
 
 [[package]]
@@ -299,6 +312,24 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.11.5"
 source = { registry = "https://pypi.org/simple" }
@@ -399,6 +430,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581, upload-time = "2025-01-06T17:26:30.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293, upload-time = "2025-01-06T17:26:25.553Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/aa/405082ce2749be5398045152251ac69c0f3578c7077efc53431303af97ce/pytest-8.4.0.tar.gz", hash = "sha256:14d920b48472ea0dbf68e45b96cd1ffda4705f33307dcc86c676c1b5104838a6", size = 1515232, upload-time = "2025-06-02T17:36:30.03Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/de/afa024cbe022b1b318a3d224125aa24939e99b4ff6f22e0ba639a2eaee47/pytest-8.4.0-py3-none-any.whl", hash = "sha256:f40f825768ad76c0977cbacdf1fd37c6f7a468e460ea6a0636078f8972d4517e", size = 363797, upload-time = "2025-06-02T17:36:27.859Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- ensure env var set before importing project modules
- import `MonkeyPatch` directly from pytest

## Testing
- `make tests`


------
https://chatgpt.com/codex/tasks/task_e_68448273c44c83209bafe91956a942c4